### PR TITLE
SNI and Error handling in certificate store.

### DIFF
--- a/src/Zodiac-OpenSSL-Certificates/ZdcX509CertificateStore.class.st
+++ b/src/Zodiac-OpenSSL-Certificates/ZdcX509CertificateStore.class.st
@@ -13,6 +13,10 @@ I can add certificates to the underlying openssl object.
 Class {
 	#name : #ZdcX509CertificateStore,
 	#superclass : #FFIOpaqueObject,
+	#classVars : [
+		'ERR_LIB_X509',
+		'X509_R_CERT_ALREADY_IN_HASH_TABLE'
+	],
 	#category : #'Zodiac-OpenSSL-Certificates-Base'
 }
 
@@ -22,13 +26,46 @@ ZdcX509CertificateStore class >> ffiLibraryName [
 	^ ZdcOpenSSLLibrary
 ]
 
+{ #category : #'class initialization' }
+ZdcX509CertificateStore class >> initialize [
+	ERR_LIB_X509 := 11.
+	X509_R_CERT_ALREADY_IN_HASH_TABLE := 101
+]
+
 { #category : #adding }
-ZdcX509CertificateStore >> addCertificate: aZdcX509Certificate [ 
-	
-	^ self ffiCall: #(int X509_STORE_add_cert(self, ZdcX509Certificate* aZdcX509Certificate))
+ZdcX509CertificateStore >> addCertificate: aZdcX509Certificate [
+
+	(self primAddCertificate: aZdcX509Certificate) ~= 1
+		ifTrue: [ self handleAddingError: aZdcX509Certificate  ]
 ]
 
 { #category : #'library path' }
 ZdcX509CertificateStore >> ffiLibraryName [
 	^ self class ffiLibraryName
+]
+
+{ #category : #errors }
+ZdcX509CertificateStore >> handleAddingError: aZdcX509Certificate [
+	| lib errorCode errorMsgBuffer errorMsg |
+	
+	lib := ZdcOpenSSLLibrary uniqueInstance.
+	errorCode := lib getLastErrorCode.
+	
+
+	"If the error is a duplicated certificate, we ignore it."
+	(((lib getErrorLib: errorCode) = ERR_LIB_X509) and: [ (lib getErrorReason: errorCode) = X509_R_CERT_ALREADY_IN_HASH_TABLE] )
+		ifTrue: [ ^self ].
+
+	errorMsgBuffer := ByteArray new: 500.
+		
+	lib getLastErrorStringFromErrorCode: errorCode buffer: errorMsgBuffer.
+	errorMsg := 'Adding ' , aZdcX509Certificate name , ':', errorMsgBuffer utf8Decoded.
+	
+	self error: errorMsg.
+]
+
+{ #category : #adding }
+ZdcX509CertificateStore >> primAddCertificate: aZdcX509Certificate [ 
+	
+	^ self ffiCall: #(int X509_STORE_add_cert(self, ZdcX509Certificate* aZdcX509Certificate))
 ]

--- a/src/Zodiac-OpenSSL-Tests/ZdcCertificateStoreTest.class.st
+++ b/src/Zodiac-OpenSSL-Tests/ZdcCertificateStoreTest.class.st
@@ -1,0 +1,53 @@
+Class {
+	#name : #ZdcCertificateStoreTest,
+	#superclass : #TestCase,
+	#instVars : [
+		'ssl'
+	],
+	#category : #'Zodiac-OpenSSL-Tests'
+}
+
+{ #category : #tests }
+ZdcCertificateStoreTest >> newDuplicatingCertificateValidation [
+
+	| aClass |
+	aClass := Object newAnonymousSubclass.
+	aClass addSlot: #certificateValidation.
+	aClass compile: 'certificateValidation: aValue
+	certificateValidation := aValue'.
+	
+	aClass compile: 'configureSSLSession: sslSession
+		"I call it twice, it should handle it correctly"
+		certificateValidation configureSSLSession: sslSession.
+		certificateValidation configureSSLSession: sslSession.
+	'.
+
+	^ aClass new
+]
+
+{ #category : #running }
+ZdcCertificateStoreTest >> setUp [
+	super setUp.
+	ssl := ZdcOpenSSLSession new.
+	
+]
+
+{ #category : #running }
+ZdcCertificateStoreTest >> tearDown [
+	ssl ifNotNil: #destroy.
+	super tearDown.
+	
+	
+]
+
+{ #category : #tests }
+ZdcCertificateStoreTest >> testAddingDuplicateCertificate [
+
+	| certificateValidationMock |
+			
+	certificateValidationMock := self newDuplicatingCertificateValidation.
+	certificateValidationMock certificateValidation: ssl certificateValidation.
+	
+	ssl certificateValidation: certificateValidationMock.
+	ssl setUp
+]

--- a/src/Zodiac-OpenSSL-Tests/ZdcFFIPluginRequestTest.class.st
+++ b/src/Zodiac-OpenSSL-Tests/ZdcFFIPluginRequestTest.class.st
@@ -1,0 +1,19 @@
+Class {
+	#name : #ZdcFFIPluginRequestTest,
+	#superclass : #TestCase,
+	#category : #'Zodiac-OpenSSL-Tests'
+}
+
+{ #category : #tests }
+ZdcFFIPluginRequestTest >> testGoogle [
+	
+	ZnEasy get: 'https://www.google.com'.
+
+]
+
+{ #category : #tests }
+ZdcFFIPluginRequestTest >> testPharo [
+	
+	ZnEasy get: 'https://www.pharo.org'.
+
+]

--- a/src/Zodiac-OpenSSL/ZdcAbstractOSCertificateValidation.class.st
+++ b/src/Zodiac-OpenSSL/ZdcAbstractOSCertificateValidation.class.st
@@ -37,8 +37,13 @@ ZdcAbstractOSCertificateValidation >> cachedCertificates [
 
 { #category : #validation }
 ZdcAbstractOSCertificateValidation >> configureSSLSession: sslSession [
+
 	| rootCertificates store |
+	
 	store := sslSession x509CertificateStore.
 	rootCertificates := self cachedCertificates.
-	rootCertificates do: [ :aCert | self assert: (store addCertificate: aCert) = 1 ]
+	rootCertificates do: [ :aCert | store addCertificate: aCert ].
+	
+	super configureSSLSession: sslSession.
+
 ]

--- a/src/Zodiac-OpenSSL/ZdcOpenSSLLibrary.class.st
+++ b/src/Zodiac-OpenSSL/ZdcOpenSSLLibrary.class.st
@@ -28,13 +28,13 @@ ZdcOpenSSLLibrary >> getErrorLib: anErrorCode [
 ZdcOpenSSLLibrary >> getErrorReason: anErrorCode [ 
 
 	"# define ERR_GET_REASON(l)       (int)( (l)         & 0xFFFL)"
-	^ anErrorCode & 16rFFFF
+	^ anErrorCode & 16rFFF
 ]
 
 { #category : #'accessing platform' }
 ZdcOpenSSLLibrary >> getLastErrorCode [
 
-	^ self ffiCall: #(int ERR_get_error())
+	^ self ffiCall: #(ulong ERR_get_error())
 ]
 
 { #category : #'accessing platform' }

--- a/src/Zodiac-OpenSSL/ZdcOpenSSLLibrary.class.st
+++ b/src/Zodiac-OpenSSL/ZdcOpenSSLLibrary.class.st
@@ -10,6 +10,27 @@ ZdcOpenSSLLibrary >> defaultCertificateFile [
 	self ffiCall: #(String X509_get_default_cert_file())
 ]
 
+{ #category : #errors }
+ZdcOpenSSLLibrary >> getErrorFunction: anErrorCode [ 
+
+	"# define ERR_GET_FUNC(l)         (int)(((l) >> 12L) & 0xFFFL)"
+	^ anErrorCode >> 12 & 16rFFF
+]
+
+{ #category : #errors }
+ZdcOpenSSLLibrary >> getErrorLib: anErrorCode [ 
+
+	"# define ERR_GET_LIB(l)          (int)(((l) >> 24L) & 0x0FFL)"
+	^ anErrorCode >> 24 & 16rFF
+]
+
+{ #category : #errors }
+ZdcOpenSSLLibrary >> getErrorReason: anErrorCode [ 
+
+	"# define ERR_GET_REASON(l)       (int)( (l)         & 0xFFFL)"
+	^ anErrorCode & 16rFFFF
+]
+
 { #category : #'accessing platform' }
 ZdcOpenSSLLibrary >> getLastErrorCode [
 

--- a/src/Zodiac-OpenSSL/ZdcOpenSSLSession.class.st
+++ b/src/Zodiac-OpenSSL/ZdcOpenSSLSession.class.st
@@ -15,6 +15,7 @@ Class {
 		'certificateValidation'
 	],
 	#classVars : [
+		'SSL_CTRL_Options',
 		'SSL_CTRL_SET_TLSEXT_HOSTNAME',
 		'SSL_ERROR_WANT_READ',
 		'SSL_ERROR_WANT_X509_LOOKUP',
@@ -79,7 +80,9 @@ ZdcOpenSSLSession class >> initialize [
 	SSL_VERIFY_POST_HANDSHAKE := 8.
 	
 	SSL_CTRL_SET_TLSEXT_HOSTNAME := 55.
-	TLSEXT_NAMETYPE_host_name := 0
+	TLSEXT_NAMETYPE_host_name := 0.
+	
+	SSL_CTRL_Options := 32
 ]
 
 { #category : #installation }
@@ -141,7 +144,11 @@ ZdcOpenSSLSession >> connect: srcBuffer from: start to: stop into: dstBuffer [
 	connectResult <= 0 ifTrue: [ 
 		^ (self wantsReadMore: connectResult)
 			ifTrue: [ writeBuffer readInto: dstBuffer size: dstBuffer size ]
-			ifFalse: [ -2 ]].
+			ifFalse: [ 
+				self flag:#todo.
+				"This is performed in this ugly way, as the client code is not intended to handle exceptions. A better way should be performed"
+				('SSL Error:' , (self getSSLErrorForReturnCode: -1) printString , ZdcOpenSSLLibrary uniqueInstance getLastErrorString) logCr. 
+				 ^ -2 ]].
 
 	self setConnectedState.
 	certificateValidation validateCertificate: self.
@@ -379,6 +386,13 @@ ZdcOpenSSLSession >> setDefaultVerifyPathToContext: aContext [
 ]
 
 { #category : #primitives }
+ZdcOpenSSLSession >> setOptions: optionFlaggish toContext: aContext [
+
+	"ExternalAddress loadSymbol: #'SSL_CTX_ctrl' module:'libssl'"
+	^ self setControlCommand: SSL_CTRL_Options larg: optionFlaggish parg: ExternalAddress null toContext: aContext
+]
+
+{ #category : #primitives }
 ZdcOpenSSLSession >> setPrivateKeyFileToContext: aContext [
 
 	^ self ffiCall: #(int SSL_CTX_use_PrivateKey_file(void* aContext, String privateKeyName, int type))
@@ -408,7 +422,7 @@ ZdcOpenSSLSession >> setUp [
 	self assert: context isNull not.
 	
 	"SSLv2 and SSLv3 are deprecated"
-	"self setOptions: SSL_OP_NO_SSLv2 | SSL_OP_NO_SSLv3 toContext: context."
+	self setOptions: SSL_OP_NO_SSLv2 | SSL_OP_NO_SSLv3 toContext: context.
 	
 	certificateName ifNotNil: [
 		self setCertificateFileToContext: context ].
@@ -425,6 +439,8 @@ ZdcOpenSSLSession >> setUp [
 	readBuffer := ZdcMemoryBIO new setAutoClose.
 	writeBuffer := ZdcMemoryBIO new setAutoClose.
 	self setBioRead: readBuffer handle bioWrite: writeBuffer handle toSSL: ssl.
+	
+	serverName ifNotNil: [ self primitiveSetHostName: serverName ].
 	
 	certificateValidation configureSSLSession: self
 ]

--- a/src/Zodiac-OpenSSL/ZdcOpenSSLSession.class.st
+++ b/src/Zodiac-OpenSSL/ZdcOpenSSLSession.class.st
@@ -131,6 +131,16 @@ ZdcOpenSSLSession >> certificateName: aString [
 	certificateName := aString
 ]
 
+{ #category : #accessing }
+ZdcOpenSSLSession >> certificateValidation [
+	^ certificateValidation
+]
+
+{ #category : #accessing }
+ZdcOpenSSLSession >> certificateValidation: anObject [
+	certificateValidation := anObject
+]
+
 { #category : #operations }
 ZdcOpenSSLSession >> connect: srcBuffer from: start to: stop into: dstBuffer [
 	| connectResult |


### PR DESCRIPTION
Better handling of certificate adding errors.
Ignoring the case when the same certificate is added twice.Adding the SNI into the client to handle servers requiring the name of the server (SNI)